### PR TITLE
added flag for automation

### DIFF
--- a/scripts/env-setup.sh
+++ b/scripts/env-setup.sh
@@ -6,16 +6,17 @@
 # Config goes into: /usr/local/etc/scanoss/geoprovenance
 # Logs go into: /var/log/scanoss/geoprovenance
 # Service definition goes into: /etc/systemd/system
-# Binary & startup º into: /usr/local/bin
+# Binary & startup go into: /usr/local/bin
 #
 ################################################################
 
-if [ "$1" = "-h" ] || [ "$1" = "-help" ] ; then
-  echo "$0 [-help] [environment]"
-  echo "   Setup and copy the relevant files into place on a server to run the SCANOSS GEO PROVENANCE API"
-  echo "   [environment] allows the optional specification of a suffix to allow multiple services to be deployed at the same time (optional)"
+show_help() {
+  echo "$0 [-h|--help] [-f|--force] [environment]"
+  echo "   Setup and copy the required files into place on a server to run the SCANOSS GEO PROVENANCE API"
+  echo "   [environment] allows the optional specification of a suffix to allow multiple services"
+  echo "   -f | --force   Run without interactive prompts (skip questions, do not overwrite config)"
   exit 1
-fi
+}
 
 CONF_DIR=/usr/local/etc/scanoss/geoprovenance
 LOGS_DIR=/var/log/scanoss/geoprovenance
@@ -26,21 +27,22 @@ FORCE_INSTALL=0
 
 export SCRIPT_DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" &> /dev/null && pwd )"
 
-while getopts ":ye:" opt; do
-  case $opt in
-    y)
+# --- Parse arguments ---
+while [[ $# -gt 0 ]]; do
+  case "$1" in
+    -h|--help)
+      show_help
+      ;;
+    -f|--force)
       FORCE_INSTALL=1
+      shift
       ;;
-    e)
-      ENVIRONMENT="$OPTARG"
-      ;;
-    \?)
-      echo "Invalid option: -$OPTARG" >&2
+    *)
+      ENVIRONMENT="$1"
+      shift
       ;;
   esac
 done
-
-shift $((OPTIND - 1))
 
 # Makes sure the scanoss user exists
 export RUNTIME_USER=scanoss
@@ -56,121 +58,115 @@ if [ "$EUID" -ne 0 ] ; then
 fi
 
 if [ "$FORCE_INSTALL" -eq 1 ]; then
-  echo "Forcing installation..."
+  echo "[FORCE] Installing Geo Provenance API $ENVIRONMENT without prompts..."
 else
   read -p "Install Geo Provenance API $ENVIRONMENT (y/n) [n]? " -n 1 -r
   echo
-  if [[ $REPLY =~ ^[Yy]$ ]]; then
-    echo "Starting installation..."
-  else
+  if [[ ! $REPLY =~ ^[Yy]$ ]]; then
     echo "Stopping."
     exit 1
   fi
 fi
+
 # Setup all the required folders and ownership
 echo "Setting up Geo Provenance API system folders..."
-if ! mkdir -p "$CONF_DIR" ; then
-  echo "mkdir failed"
-  exti 1
-fi
-if ! mkdir -p "$LOGS_DIR" ; then
-  echo "mkdir failed"
-  exit 1
-fi
+mkdir -p "$CONF_DIR" || { echo "mkdir failed"; exit 1; }
+mkdir -p "$LOGS_DIR" || { echo "mkdir failed"; exit 1; }
+
 if [ "$RUNTIME_USER" != "root" ] ; then
   export LOG_DIR=/var/log/scanoss
   echo "Changing ownership of $LOG_DIR to $RUNTIME_USER ..."
-  if ! chown -R $RUNTIME_USER $LOG_DIR ; then
-    echo "chown of $LOG_DIR to $RUNTIME_USER failed"
-    exit 1
-  fi
+  chown -R $RUNTIME_USER $LOG_DIR || { echo "chown of $LOG_DIR failed"; exit 1; }
 fi
-# Setup the service on the system (defaulting to service name without environment)
+
+# Setup the service
 SC_SERVICE_FILE="scanoss-geoprovenance-api.service"
 SC_SERVICE_NAME="scanoss-geoprovenance-api"
 if [ -n "$ENVIRONMENT" ] ; then
   SC_SERVICE_FILE="scanoss-geoprovenance-api-${ENVIRONMENT}.service"
   SC_SERVICE_NAME="scanoss-geoprovenance-api-${ENVIRONMENT}"
 fi
-export service_stopped=""
+
+service_stopped=""
 if [ -f "/etc/systemd/system/$SC_SERVICE_FILE" ] ; then
   echo "Stopping $SC_SERVICE_NAME service first..."
-  if ! systemctl stop "$SC_SERVICE_NAME" ; then
-    echo "service stop failed"
-    exit 1
-  fi
-  export service_stopped="true"
+  systemctl stop "$SC_SERVICE_NAME" || { echo "service stop failed"; exit 1; }
+  service_stopped="true"
 fi
+
 echo "Copying service startup config..."
 if [ -f "$SCRIPT_DIR/$SC_SERVICE_FILE" ] ; then
-  if ! cp "$SCRIPT_DIR/$SC_SERVICE_FILE" /etc/systemd/system ; then
-    echo "service copy failed"
-    exti 1
-  fi
+  cp "$SCRIPT_DIR/$SC_SERVICE_FILE" /etc/systemd/system || { echo "service copy failed"; exit 1; }
 else 
   echo "No service file found at $SCRIPT_DIR/$SC_SERVICE_FILE"
 fi
-if ! cp $SCRIPT_DIR/scanoss-geoprovenance-api.sh /usr/local/bin ; then
-  echo "Provenance api startup script copy failed"
-  exit 1
-fi
-if ! chmod +x /usr/local/bin/scanoss-geoprovenance-api.sh ; then
-  echo "Provenance api startup script permissions failed"
-  exit 1
-fi
-# Copy in the configuration file if requested
+
+cp "$SCRIPT_DIR/scanoss-geoprovenance-api.sh" /usr/local/bin || { echo "startup script copy failed"; exit 1; }
+chmod +x /usr/local/bin/scanoss-geoprovenance-api.sh
+
+# Config file
 CONF=app-config-prod.json
 if [ -n "$ENVIRONMENT" ] ; then
   CONF="app-config-${ENVIRONMENT}.json"
 fi
-if [ -f "$SCRIPT_DIR/$CONF" ] ; then
-  echo "Copying app config to $CONF_DIR ..."
-  if ! cp "$SCRIPT_DIR/$CONF" "$CONF_DIR/" ; then
-    echo "copy $CONF failed"
-    exit 1
+
+if [ -f "$SCRIPT_DIR/$CONF" ]; then
+  if [ -f "$CONF_DIR/$CONF" ]; then
+    if [ "$FORCE_INSTALL" -eq 1 ]; then
+      echo "[FORCE] Config already exists at $CONF_DIR/$CONF, skipping replacement."
+    else
+      read -p "Config file exists. Replace $CONF_DIR/$CONF? (y/n) [n]? " -n 1 -r
+      echo
+      if [[ $REPLY =~ ^[Yy]$ ]]; then
+        cp "$SCRIPT_DIR/$CONF" "$CONF_DIR/" || { echo "config copy failed"; exit 1; }
+      else
+        echo "Skipping config copy."
+      fi
+    fi
+  else
+    cp "$SCRIPT_DIR/$CONF" "$CONF_DIR/" || { echo "config copy failed"; exit 1; }
   fi
 else
-  if [ ! -f "$CONF_DIR/$CONF" ] ; then
-    read -p "Download sample $CONF (y/n) [y]? " -n 1 -r
-    echo
-    if [[ $REPLY =~ ^[Nn]$ ]] ; then
-      echo "Please put the config file into: $CONF_DIR/$CONF"
-    elif ! curl $CONF_DOWNLOAD > "$CONF_DIR/$CONF" ; then
-      echo "Warning: curl download failed"
+  if [ ! -f "$CONF_DIR/$CONF" ]; then
+    if [ "$FORCE_INSTALL" -eq 1 ]; then
+      echo "[FORCE] Downloading default config to $CONF_DIR/$CONF"
+      curl -s "$CONF_DOWNLOAD" > "$CONF_DIR/$CONF" || echo "Warning: curl download failed"
+    else
+      read -p "Download sample $CONF (y/n) [y]? " -n 1 -r
+      echo
+      if [[ ! $REPLY =~ ^[Nn]$ ]]; then
+        curl -s "$CONF_DOWNLOAD" > "$CONF_DIR/$CONF" || echo "Warning: curl download failed"
+      else
+        echo "Please put the config file into: $CONF_DIR/$CONF"
+      fi
     fi
   fi
 fi
-# Copy the binaries if requested
+
+# Copy the binary
 BINARY=scanoss-geoprovenance-api
 if [ -f "$SCRIPT_DIR/$BINARY" ] ; then
   echo "Copying app binary to /usr/local/bin ..."
-  if ! cp $SCRIPT_DIR/$BINARY /usr/local/bin ; then
-    echo "copy $BINARY failed"
-    echo "Please make sure the service is stopped: systemctl stop scanoss-geoprovenance-api"
-    exit 1
-  fi
-  if ! chmod +x /usr/local/bin/$BINARY ; then
-    echo "execution permission on $BINARY failed"
-    echo "Please make sure the use can set the binary as executable: chmod +x /usr/local/bin/scanoss-geoprovenance-api"
-  fi
+  cp "$SCRIPT_DIR/$BINARY" /usr/local/bin || { echo "binary copy failed"; exit 1; }
+  chmod +x /usr/local/bin/$BINARY || echo "Warning: could not set executable permission on $BINARY"
 else
-  echo "Please copy the Provenance API binary file into: /usr/local/bin/$BINARY"
+  echo "Please copy the Geo Provenance API binary file into: /usr/local/bin/$BINARY"
 fi
+
 echo "Installation complete."
 if [ "$service_stopped" == "true" ] ; then
   echo "Restarting service after install..."
-  if ! systemctl start "$SC_SERVICE_NAME" ; then
-    echo "failed to restart service"
-    exit 1
-  fi
+  systemctl start "$SC_SERVICE_NAME" || { echo "failed to restart service"; exit 1; }
   systemctl status "$SC_SERVICE_NAME"
 fi
+
 if [ ! -f "$CONF_DIR/$CONF" ] ; then
   echo
   echo "Warning: Please create a configuration file in: $CONF_DIR/$CONF"
   echo "A sample version can be downloaded from GitHub:"
   echo "curl $CONF_DOWNLOAD > $CONF_DIR/$CONF"
 fi
+
 echo
 echo "Review service config in: $CONF_DIR/$CONF"
 echo "Logs are stored in: $LOGS_DIR"
@@ -178,4 +174,3 @@ echo "Start the service using: systemctl start $SC_SERVICE_NAME"
 echo "Stop the service using: systemctl stop $SC_SERVICE_NAME"
 echo "Get service status using: systemctl status $SC_SERVICE_NAME"
 echo "Count the number of running scans using: pgrep -P \$(pgrep -d, scanoss-geoprovenance-api) | wc -l"
-echo


### PR DESCRIPTION
Added support for -f  --force flag:

Enables fully non-interactive installs.

Auto-accepts installation without user prompts.

Skips overwriting config if it already exists.

Downloads default config automatically if missing.