### PR TITLE
feat(rest): register /health liveness endpoint via go-grpc-helper v0.16.0 (SP-4474)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,12 @@ Two endpoints are available for this.
 
 ## [Unreleased]
 
+## [0.5.0] - 2026-06-22
+### Added
+- `/health` liveness endpoint (GET) on the REST gateway
+### Changed
+- Upgraded `scanoss/go-grpc-helper` to `v0.16.0`
+
 ## [0.4.0] - 2026-04-16
 ### Changed
 - Replaced `error_message`/`error_code` with `info_message`/`info_code` on per-component info

--- a/go.mod
+++ b/go.mod
@@ -8,7 +8,7 @@ require (
 	github.com/lib/pq v1.12.3
 	github.com/package-url/packageurl-go v0.1.5
 	github.com/scanoss/go-component-helper v0.6.0
-	github.com/scanoss/go-grpc-helper v0.15.1
+	github.com/scanoss/go-grpc-helper v0.16.0
 	github.com/scanoss/papi v0.38.0
 	github.com/scanoss/zap-logging-helper v0.4.0
 	go.uber.org/zap v1.27.1

--- a/go.sum
+++ b/go.sum
@@ -628,8 +628,8 @@ github.com/rogpeppe/go-internal v1.14.1 h1:UQB4HGPB6osV0SQTLymcB4TgvyWu6ZyliaW0t
 github.com/rogpeppe/go-internal v1.14.1/go.mod h1:MaRKkUm5W0goXpeCfT7UZI6fk/L7L7so1lCWt35ZSgc=
 github.com/scanoss/go-component-helper v0.6.0 h1:tizjG6Fue2mWZLFtnHP8I6OaPze03Im5AfqBcNfW4bo=
 github.com/scanoss/go-component-helper v0.6.0/go.mod h1:UwsyuM5uvCrGeBIkvewgMAKV92Sjjvo7zelq4c2m91Y=
-github.com/scanoss/go-grpc-helper v0.15.1 h1:tiI7JXVj2LYpktkYVqCcUd6XyMi6aVcAKRecNR5QGCA=
-github.com/scanoss/go-grpc-helper v0.15.1/go.mod h1:UjrF9hewgZxstUC3+F0PJnuOXH0bChmsbcJp7e7OsH4=
+github.com/scanoss/go-grpc-helper v0.16.0 h1:RwFY2iZQ9JQWR0kewBviF1MevfpCBdkijoh+KaYRuEI=
+github.com/scanoss/go-grpc-helper v0.16.0/go.mod h1:UjrF9hewgZxstUC3+F0PJnuOXH0bChmsbcJp7e7OsH4=
 github.com/scanoss/go-models v0.8.0 h1:ANprMXby+J9vxj205EfH7roVzAsUJdcTenytPea4N/k=
 github.com/scanoss/go-models v0.8.0/go.mod h1:gkXP2/3ZUn8IyH/z/528aTcWZ2mzlzsXiY4bzBbrM+o=
 github.com/scanoss/go-purl-helper v0.3.0 h1:zH5rcYbmYTvKms2oWrYV+8rWZ2ElLgDIOy2jZ9XhAg0=

--- a/pkg/protocol/rest/server.go
+++ b/pkg/protocol/rest/server.go
@@ -38,6 +38,10 @@ func RunServer(config *myconfig.ServerConfig, ctx context.Context, grpcPort, htt
 	if err != nil {
 		return nil, err
 	}
+	// register the liveness /health endpoint on the gateway mux
+	if err = gw.RegisterHealthEndpoint(mux); err != nil {
+		return nil, err
+	}
 	// Open TCP port (in the background) and listen for requests
 	go func() {
 		ctx2, cancel := context.WithCancel(ctx)


### PR DESCRIPTION
## What
- Bumps `go-grpc-helper` to **v0.16.0** and registers a real **GET /health** liveness route on the gateway mux.

## Why
The geoprovenance service (`scanoss-geoprovenance-api`) exposed no real `/health` route — the gateway returns 200 for any path (error-handler quirk), so the LB can't actively health-check it. This adds a real GET-only liveness endpoint, consistent with dependencies/components/vulnerabilities/cryptography/licenses.

Parent bug: SP-4472. SP-4474.

## Test
- `go build ./...` ✅, `golangci-lint run ./...` → 0 issues ✅

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a `/health` GET endpoint to the REST gateway, enabling clients to check application liveness and health status.

* **Chores**
  * Updated dependencies to incorporate latest improvements and maintain compatibility with supporting libraries.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->